### PR TITLE
Clean up indentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ While not required, it is recommended you use
 [pipenv](https://github.com/pypa/pipenv) to create an isolated environment for
 running and developing.  To do so, run
 ```bash
-    pipenv install --dev
+pipenv install --dev
 ```
 
 See [pipenv](https://pipenv.kennethreitz.org/) for details.  Once this is done,
@@ -23,16 +23,16 @@ are running the simulation from.
 
 ## Running
 
-### Run with python virtual environment
+### Run with Python virtual environment
 
 With the simulation package installed, you should have a new command-line
 program called `nlisim ` available.  Try running `nlisim --help` to get
 more information.  To run a simulation, you will need configure a configuration.
 There is an example configuration in the repository to get you started.
 
-Now run simulation up to 50 timesteps using the first example config.
+Now run simulation up to 50 timesteps using the first example config:
 ```bash
-    nlisim --config config.ini.example run 50
+nlisim --config config.ini.example run 50
 ```
 
 ### Run with Docker
@@ -66,7 +66,7 @@ them within the container; this example uses `--mount` to
 There is a basic test suite included in the package using [tox](https://tox.readthedocs.io/en/latest/)
 as a test runner.  Try running the tests now with
 ```bash
-    tox
+tox
 ```
 
 This will install the simulation code into a new isolated environment and run
@@ -180,25 +180,25 @@ An extension module is registered with the simulation by providing a subclass
 of `nlisim.module.Module`.  Features are added by overriding attributes on
 this class.  The following is small example demonstrating some of the features:
 ```python
-    import attr
+import attr
 
-    from nlisim.module import ModuleModel, ModuleState
+from nlisim.module import ModuleModel, ModuleState
 
 
-    class HelloWorld(ModuleModel):
-        name = 'hello_world'
+class HelloWorld(ModuleModel):
+    name = 'hello_world'
 
-        @attr.s(kw_only=True, auto_attribs=True)
-        class StateClass(ModuleState):
-            target: str = attr.ib(default='')
+    @attr.s(kw_only=True, auto_attribs=True)
+    class StateClass(ModuleState):
+        target: str = attr.ib(default='')
 
-        def initialize(self, state):
-            state.hello_world.target = self.config.get('target_string')
-            return state
+    def initialize(self, state):
+        state.hello_world.target = self.config.get('target_string')
+        return state
 
-        def advance(self, state, previous_time):
-            print(f'Hello {state.hello_world.target}!')
-            return state
+    def advance(self, state, previous_time):
+        print(f'Hello {state.hello_world.target}!')
+        return state
 ```
 
 When enabled, this module will
@@ -217,19 +217,19 @@ To visualize the output of the simulation, please add the variable names to the 
 [visualization]
 # vtk_type: STRUCTURED_POINTS, STRUCTURED_GRID, RECTILINEAR_GRID, UNSTRUCTURED_GRID, POLY_DATA
 visual_variables =  [
-                        {
-                            "module":"afumigatus",
-                            "variable":"tree",
-                            "vtk_type":"POLY_DATA",
-                            "attributes":["iron_pool", "iteration"]
-                        },
-                        {
-                            "module":"geometry",
-                            "variable":"lung_tissue",
-                            "vtk_type":"STRUCTURED_POINTS",
-                            "attributes":[]
-                        }
-                    ]
+    {
+        "module":"afumigatus",
+        "variable":"tree",
+        "vtk_type":"POLY_DATA",
+        "attributes":["iron_pool", "iteration"]
+    },
+    {
+        "module":"geometry",
+        "variable":"lung_tissue",
+        "vtk_type":"STRUCTURED_POINTS",
+        "attributes":[]
+    }
+]
 ```
 
 For example, to visualize the aspergillus and the alveolar geometry, the variable `afumigatus.tree` with attributes `iron_pool` and `iteration` and the variable `geometry.lung_tissue` are added to the list, followed by their [VTK dataset formats](https://vtk.org/wp-content/uploads/2015/04/file-formats.pdf).


### PR DESCRIPTION
There's no need to indent code blocks, and it makes copy-pasting more difficult.