### PR TITLE
Add a unit label to the progress bar

### DIFF
--- a/nlisim/cli.py
+++ b/nlisim/cli.py
@@ -39,6 +39,7 @@ def run(obj, target_time: float) -> None:
 
     with tqdm(
         desc='Running simulation',
+        unit='step',
         total=target_time,
     ) as pbar:
         for state, _ in run_iterator(config, target_time):


### PR DESCRIPTION
This makes it display as "s/step" instead of "s/it".