### PR TITLE
Clean up the release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,19 +43,15 @@ jobs:
 
   release:
     docker:
-      - image: jbeezley/tox:latest
+      - image: circleci/python:3.8
     steps:
       - checkout
       - run:
-          name: Install twine
-          command: pip3 install twine
+          name: Install tox
+          command: sudo pip install tox
       - run:
-          name: Build sdist
+          name: Make release
           command: tox -e release
-      - run:
-          name: Upload release
-          command: twine upload --skip-existing dist/*.tar.gz
-
 
 workflows:
   version: 2

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def prerelease_local_scheme(version):
     """
     from setuptools_scm.version import get_local_node_and_date
 
-    if 'CI_COMMIT_REF_NAME' in os.environ and os.environ['CI_COMMIT_REF_NAME'] == 'master':
+    if 'CIRCLE_BRANCH' in os.environ and os.environ['CIRCLE_BRANCH'] == 'master':
         return ''
     else:
         return get_local_node_and_date(version)

--- a/tox.ini
+++ b/tox.ini
@@ -50,12 +50,15 @@ deps =
 commands = pdoc3 -o docs --config latex_math=True --force --html nlisim
 
 [testenv:release]
-basepython = python3
-skipdist = true
-skip_install = true
-passenv = CI_COMMIT_REF_NAME
-deps = setuptools_scm
-commands = python setup.py sdist
+passenv =
+    CIRCLE_BRANCH
+    TWINE_USERNAME
+    TWINE_PASSWORD
+deps =
+    twine
+commands =
+    twine check {distdir}/*
+    twine upload --skip-existing {distdir}/*
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
This now does the release build cleanly within Tox. It also updates the environment variables in `prerelease_local_scheme` to those used by CircleCI.