### PR TITLE
Use isort for import ordering

### DIFF
--- a/nlisim/cell.py
+++ b/nlisim/cell.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, cast, Dict, Iterable, List, Set, Type, Union
+from typing import Any, Dict, Iterable, List, Set, Type, Union, cast
 
 import attr
 from h5py import Group
@@ -7,7 +7,7 @@ import numpy as np
 
 from nlisim.coordinates import Point, Voxel
 from nlisim.grid import RectangularGrid
-from nlisim.state import get_class_path, State
+from nlisim.state import State, get_class_path
 
 MAX_CELL_LIST_SIZE = 1000000
 

--- a/nlisim/cli.py
+++ b/nlisim/cli.py
@@ -10,7 +10,6 @@ from nlisim.config import SimulationConfig
 from nlisim.postprocess import process_output
 from nlisim.solver import run_iterator
 
-
 InputFilePath = click_pathlib.Path(exists=True, file_okay=True, dir_okay=False, readable=True)
 OutputDirPath = click_pathlib.Path(file_okay=False, dir_okay=True, writable=True)
 

--- a/nlisim/config.py
+++ b/nlisim/config.py
@@ -4,7 +4,7 @@ from importlib import import_module
 from io import StringIO, TextIOBase
 from pathlib import PurePath
 import re
-from typing import List, Optional, TextIO, Type, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, List, Optional, TextIO, Type, Union
 
 if TYPE_CHECKING:
     from nlisim.module import ModuleModel  # noqa

--- a/nlisim/modules/afumigatus.py
+++ b/nlisim/modules/afumigatus.py
@@ -13,7 +13,7 @@ from nlisim.coordinates import Point
 from nlisim.grid import RectangularGrid
 from nlisim.module import ModuleModel, ModuleState
 from nlisim.random import rg
-from nlisim.state import get_class_path, State
+from nlisim.state import State, get_class_path
 
 
 class AfumigatusCellData(CellData):

--- a/nlisim/modules/epithelium.py
+++ b/nlisim/modules/epithelium.py
@@ -12,7 +12,6 @@ from nlisim.modules.geometry import TissueTypes
 from nlisim.random import rg
 from nlisim.state import State
 
-
 MAX_PHAGOSOME_LENGTH = 100
 
 

--- a/nlisim/modules/geometry.py
+++ b/nlisim/modules/geometry.py
@@ -6,7 +6,7 @@ import numpy as np
 import vtk
 
 from nlisim.module import ModuleModel, ModuleState
-from nlisim.state import grid_variable, State
+from nlisim.state import State, grid_variable
 from nlisim.validation import ValidationError
 
 

--- a/nlisim/molecule.py
+++ b/nlisim/molecule.py
@@ -6,7 +6,7 @@ from h5py import Group
 import numpy as np
 
 from nlisim.grid import RectangularGrid
-from nlisim.state import get_class_path, State
+from nlisim.state import State, get_class_path
 
 
 @unique

--- a/nlisim/state.py
+++ b/nlisim/state.py
@@ -1,6 +1,6 @@
 from io import BytesIO, StringIO
 from pathlib import PurePath
-from typing import Any, cast, Dict, IO, Type, TYPE_CHECKING, Union
+from typing import IO, TYPE_CHECKING, Any, Dict, Type, Union, cast
 
 import attr
 from h5py import File as H5File

--- a/nlisim/validation.py
+++ b/nlisim/validation.py
@@ -1,6 +1,5 @@
 from contextlib import contextmanager
-from typing import Callable, Iterator, List, TYPE_CHECKING
-
+from typing import TYPE_CHECKING, Callable, Iterator, List
 
 if TYPE_CHECKING:  # prevent circular imports for type checking
     from nlisim.state import State  # noqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,13 @@
 [tool.black]
 line-length = 100
 skip-string-normalization = true
-target-version = ['py37']
+target-version = ["py37"]
 exclude='\.eggs|\.git|\.mypy_cache|\.tox|\.venv|_build|buck-out|build|dist'
+
+[tool.isort]
+profile = "black"
+line_length = 100
+# Sort by name, don't cluster "from" vs "import"
+force_sort_within_sections = true
+# Combines "as" imports on the same line
+combine_as_imports = true

--- a/test/test_afumigatus.py
+++ b/test/test_afumigatus.py
@@ -1,4 +1,4 @@
-from typing import cast, Set
+from typing import Set, cast
 
 from h5py import Group
 from pytest import fixture
@@ -6,11 +6,7 @@ from pytest import fixture
 from nlisim.config import SimulationConfig
 from nlisim.coordinates import Point
 from nlisim.grid import RectangularGrid
-from nlisim.modules.afumigatus import (
-    AfumigatusCellData,
-    AfumigatusCellTreeList,
-    AfumigatusState,
-)
+from nlisim.modules.afumigatus import AfumigatusCellData, AfumigatusCellTreeList, AfumigatusState
 from nlisim.state import State
 
 Status = AfumigatusCellData.Status

--- a/test/test_epithelium.py
+++ b/test/test_epithelium.py
@@ -3,14 +3,8 @@ from pytest import fixture
 
 from nlisim.coordinates import Point
 from nlisim.grid import RectangularGrid
-from nlisim.modules.epithelium import (
-    EpitheliumCellData,
-    EpitheliumCellList,
-)
-from nlisim.modules.fungus import (
-    FungusCellData,
-    FungusCellList,
-)
+from nlisim.modules.epithelium import EpitheliumCellData, EpitheliumCellList
+from nlisim.modules.fungus import FungusCellData, FungusCellList
 
 
 @fixture

--- a/test/test_fungus.py
+++ b/test/test_fungus.py
@@ -3,10 +3,7 @@ from pytest import fixture
 
 from nlisim.coordinates import Point
 from nlisim.grid import RectangularGrid
-from nlisim.modules.fungus import (
-    FungusCellData,
-    FungusCellList,
-)
+from nlisim.modules.fungus import FungusCellData, FungusCellList
 
 
 @fixture

--- a/test/test_macrophage.py
+++ b/test/test_macrophage.py
@@ -3,14 +3,8 @@ from pytest import fixture
 
 from nlisim.coordinates import Point
 from nlisim.grid import RectangularGrid
-from nlisim.modules.fungus import (
-    FungusCellData,
-    FungusCellList,
-)
-from nlisim.modules.macrophage import (
-    MacrophageCellData,
-    MacrophageCellList,
-)
+from nlisim.modules.fungus import FungusCellData, FungusCellList
+from nlisim.modules.macrophage import MacrophageCellData, MacrophageCellList
 
 
 @fixture

--- a/test/test_neutrophil.py
+++ b/test/test_neutrophil.py
@@ -3,14 +3,8 @@ from pytest import fixture
 
 from nlisim.coordinates import Point
 from nlisim.grid import RectangularGrid
-from nlisim.modules.fungus import (
-    FungusCellData,
-    FungusCellList,
-)
-from nlisim.modules.neutrophil import (
-    NeutrophilCellData,
-    NeutrophilCellList,
-)
+from nlisim.modules.fungus import FungusCellData, FungusCellList
+from nlisim.modules.neutrophil import NeutrophilCellData, NeutrophilCellList
 
 
 @fixture

--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -1,7 +1,7 @@
 import attr
 import pytest
 
-from nlisim.validation import context, ValidationError
+from nlisim.validation import ValidationError, context
 
 
 def test_validate_initial_state(config, state):

--- a/tox.ini
+++ b/tox.ini
@@ -13,10 +13,8 @@ commands =
 skipsdist = true
 skip_install = true
 deps =
-    black
     flake8
     flake8-black
-    flake8-blind-except
     flake8-bugbear
     flake8-docstrings
     flake8-isort

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ commands =
     pytest {posargs} test
 
 [testenv:lint]
-basepython = python3
 skipsdist = true
 skip_install = true
 deps =
@@ -20,19 +19,20 @@ deps =
     flake8-blind-except
     flake8-bugbear
     flake8-docstrings
-    flake8-import-order
+    flake8-isort
     flake8-quotes
     pep8-naming
 commands =
     flake8 {posargs:.}
 
 [testenv:format]
-basepython = python3
 skipsdist = true
 skip_install = true
 deps =
     black
+    isort
 commands =
+    isort {posargs:.}
     black {posargs:.}
 
 [testenv:type]


### PR DESCRIPTION
This has the major benefit of automatically sorting imports on behalf of the developer, during `tox -e format`, as opposed to `flake8-import-order` which requires manual resolution every time.