### PR TITLE
Summary stats

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -17,15 +17,13 @@ validate = True
 
 # a list of modules to run with the simulation
 modules = nlisim.modules.geometry.Geometry
-          nlisim.modules.visualization.Visualization
           nlisim.modules.molecules.Molecules
           nlisim.modules.fungus.Fungus
           nlisim.modules.epithelium.Epithelium
           #nlisim.modules.save.FileOutput
           nlisim.modules.macrophage.Macrophage
           nlisim.modules.neutrophil.Neutrophil
-
-
+          nlisim.modules.visualization.Visualization
 
 [file_output]
 # save the simulation state every 1 simulation second

--- a/nlisim/module.py
+++ b/nlisim/module.py
@@ -167,5 +167,9 @@ class ModuleModel(object):
         return state
 
     def summary_stats(self, state: State) -> Dict[str, Any]:
-        """Run to provide informative statistics based on the module's current state."""
+        """Run to provide informative statistics based on the module's current state.
+
+        Note: Json encoder does not support numpy data-types (e.g. np.float32) so it
+        is important to cast these values to standard python types.
+        """
         return dict()

--- a/nlisim/modules/epithelium.py
+++ b/nlisim/modules/epithelium.py
@@ -1,7 +1,6 @@
 from enum import IntEnum
 import itertools
 from random import shuffle
-from typing import Any, Dict
 
 import attr
 import numpy as np

--- a/nlisim/modules/epithelium.py
+++ b/nlisim/modules/epithelium.py
@@ -285,8 +285,3 @@ class Epithelium(ModuleModel):
         cells.die_by_germination(spores)
 
         return state
-
-    def summary_stats(self, state: State) -> Dict[str, Any]:
-        # epithelium : EpitheliumState = state.epithelium
-        # TODO: what are the useful statistics here?
-        return {}

--- a/nlisim/modules/fungus.py
+++ b/nlisim/modules/fungus.py
@@ -342,7 +342,7 @@ class Fungus(ModuleModel):
 
         return {
             'count': len(fungus.cells.alive()),
-            'conidia': num_conidia,
-            'hyphae': num_hyphae,
-            'total_iron': total_iron,
+            'conidia': int(num_conidia),
+            'hyphae': int(num_hyphae),
+            'total_iron': float(total_iron),
         }

--- a/nlisim/modules/macrophage.py
+++ b/nlisim/modules/macrophage.py
@@ -340,5 +340,5 @@ class Macrophage(ModuleModel):
 
         return {
             'count': len(macrophage.cells.alive()),
-            'phagosome': num_phagosome,
+            'phagosome': int(num_phagosome),
         }

--- a/nlisim/modules/molecules.py
+++ b/nlisim/modules/molecules.py
@@ -215,13 +215,13 @@ class Molecules(ModuleModel):
         iron = molecules.grid['iron']
 
         return {
-            'm_cyto_max': np.max(m_cyto),
-            'm_cyto_min': np.min(m_cyto),
-            'm_cyto_mean': np.mean(m_cyto),
-            'n_cyto_max': np.max(n_cyto),
-            'n_cyto_min': np.min(n_cyto),
-            'n_cyto_mean': np.mean(n_cyto),
-            'iron_max': np.max(iron),
-            'iron_min': np.min(iron),
-            'iron_mean': np.mean(iron),
+            'm_cyto_max': float(np.max(m_cyto)),
+            'm_cyto_min': float(np.min(m_cyto)),
+            'm_cyto_mean': float(np.mean(m_cyto)),
+            'n_cyto_max': float(np.max(n_cyto)),
+            'n_cyto_min': float(np.min(n_cyto)),
+            'n_cyto_mean': float(np.mean(n_cyto)),
+            'iron_max': float(np.max(iron)),
+            'iron_min': float(np.min(iron)),
+            'iron_mean': float(np.mean(iron)),
         }

--- a/nlisim/modules/neutrophil.py
+++ b/nlisim/modules/neutrophil.py
@@ -302,5 +302,5 @@ class Neutrophil(ModuleModel):
 
         return {
             'count': len(neutrophil.cells.alive()),
-            'granules': neutrophil.granule_count,
+            'granules': int(neutrophil.granule_count),
         }


### PR DESCRIPTION
json serialization requires that all floats are standard python float's, not e.g. numpy.float32's